### PR TITLE
Fix a flicker in the #currency test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 PATH
   remote: .
   specs:
-    phil (0.9.7)
+    phil (0.9.8)
       activesupport
-      ffaker (>= 2.0.0)
+      ffaker (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.1)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     diff-lcs (1.2.5)
-    ffaker (2.0.0)
+    ffaker (2.1.0)
     i18n (0.7.0)
-    json (1.8.2)
-    minitest (5.5.1)
+    json (1.8.3)
+    minitest (5.8.1)
     ox (2.0.11)
     rake (10.1.0)
     rspec (2.14.1)

--- a/spec/phil_spec.rb
+++ b/spec/phil_spec.rb
@@ -454,7 +454,7 @@ describe Phil do
       end
 
       it "formats the currency to two decimal places" do
-        expect(c).to match(/\$\d{2}\.\d{2}/)
+        expect(c).to match(/\$\d{2,3}\.\d{2}/)
       end
     end
 


### PR DESCRIPTION
Occasionally this test expects a three digit result, and fails due
to the regex.

Includes standard dependency updates.
