### PR TITLE
Fix a flicker in the #date test

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 PATH
   remote: .
   specs:
-    phil (0.9.7)
+    phil (0.9.8)
       activesupport
-      ffaker (>= 2.0.0)
+      ffaker (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.1)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     diff-lcs (1.2.5)
-    ffaker (2.0.0)
+    ffaker (2.1.0)
     i18n (0.7.0)
-    json (1.8.2)
-    minitest (5.5.1)
+    json (1.8.3)
+    minitest (5.8.1)
     ox (2.0.11)
     rake (10.1.0)
     rspec (2.14.1)

--- a/spec/phil_spec.rb
+++ b/spec/phil_spec.rb
@@ -427,8 +427,8 @@ describe Phil do
 
     context 'custom date window range' do
 
-      let(:two_months_ago) { Time.now - 86400 * 60 }
-      let(:month_ago) { Time.now - 86400 * 30 }
+      let(:two_months_ago) { Time.now - 86400 * 60 - 1 }
+      let(:month_ago) { Time.now - 86400 * 30 + 1 }
       let(:d) { Phil.date 30..60 }
 
       it 'returns a date in the last 30-60 days' do


### PR DESCRIPTION
This test always fails when `:d` equals 30, and sometimes fails when `:d` equals 60, due to microsecond time differences.

Adding a second on either end fixes the flicker.
