### PR TITLE
Fix a flicker in #currency when cents are above $100

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 PATH
   remote: .
   specs:
-    phil (0.9.7)
+    phil (0.9.8)
       activesupport
-      ffaker (>= 2.0.0)
+      ffaker (~> 2.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.1)
+    activesupport (4.2.4)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     diff-lcs (1.2.5)
-    ffaker (2.0.0)
+    ffaker (2.1.0)
     i18n (0.7.0)
-    json (1.8.2)
-    minitest (5.5.1)
+    json (1.8.3)
+    minitest (5.8.1)
     ox (2.0.11)
     rake (10.1.0)
     rspec (2.14.1)

--- a/spec/phil_spec.rb
+++ b/spec/phil_spec.rb
@@ -442,14 +442,14 @@ describe Phil do
 
     context 'default currency' do
 
-      let(:amount) { 10..100 }
+      let(:amount) { 10..100.99 }
       let(:c) { Phil.currency amount }
 
       it 'returns a string with a dollar value' do
         expect(c).to start_with('$')
       end
 
-      it "returns a dollar value within 10..100" do
+      it "returns a dollar value within 10..100.99" do
         expect(amount).to cover(c.gsub('$', '').to_f)
       end
 


### PR DESCRIPTION
When `:amount` equals 100, this test always fails because the upper limit of the range is 100, but `currency` adds cents to each dollar amount.

Extending the range by 99 cents accounts for this feature.
